### PR TITLE
Remove GitHub environment from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   test:
-    environment: "test"
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
@@ -26,7 +25,6 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
-    environment: "test"
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
@@ -43,7 +41,6 @@ jobs:
           args: "--timeout=3m"
 
   build:
-    environment: "test"
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"


### PR DESCRIPTION
Environment variables are loaded from the dev.env file during test, removing the need for the PR workflow test environment and it's associated "deploying to test" spam.